### PR TITLE
Change deprecated config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,7 +78,7 @@ highlight_language = "javascript"
 #
 html_theme = 'sphinx_rtd_theme'
 def setup(app):
-    app.add_stylesheet('css/custom.css')
+    app.add_css_file('css/custom.css')
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Change "app.add_stylesheet" to app.add_css_file as it is deprecated and removed in Sphynx 4.
`RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.`
https://www.sphinx-doc.org/en/master/changes.html
https://github.com/sphinx-doc/sphinx/pull/7416