### PR TITLE
Update GHA for docs.vircadia.dev

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -3,8 +3,7 @@ name: Master CI Build
 on:
   push:
     branches:
-#      - master
-      - translation-experiment
+      - master
 
 jobs:
   build_en_docs:
@@ -38,17 +37,17 @@ jobs:
       uses: JulianGro/SFTP-Deploy-Action@v1.4
       with:
         username: 'gha'
-        server: '94.130.177.235'
+        server: 'vircadia.dev'
         ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
         local_path: 'docs/build-archives/*'
-        remote_path: '/var/www/html/gha/'
+        remote_path: '/var/www/vhosts/release/'
         args: '-o ConnectTimeout=5'
     - name: Deploy english documentation
       shell: bash
       run: |
         printf "%s" "${{ secrets.SSH_PRIVATE_KEY }}" > private_key.pem
         chmod 600 private_key.pem
-        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@94.130.177.235 "mkdir -p /var/www/html/gha/ && tar -xvzf /var/www/html/gha/build-en.tar.gz -C /var/www/html/gha/ && rm /var/www/html/gha/build-en.tar.gz"
+        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@vircadia.dev "mkdir -p /var/www/vhosts/release/ && tar -xvzf /var/www/vhosts/release/build-en.tar.gz -C /var/www/vhosts/release/ && rm /var/www/vhosts/release/build-en.tar.gz"
 
   build_translated_docs:
     runs-on: ubuntu-20.04
@@ -89,20 +88,20 @@ jobs:
       uses: JulianGro/SFTP-Deploy-Action@v1.4
       with:
         username: 'gha'
-        server: '94.130.177.235'
+        server: 'vircadia.dev'
         ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
         local_path: 'docs/build-archives/*'
-        remote_path: '/var/www/html/gha/'
+        remote_path: '/var/www/vhost/release/'
         args: '-o ConnectTimeout=5'
     - name: Deploy german documentation
       shell: bash
       run: |
         printf "%s" "${{ secrets.SSH_PRIVATE_KEY }}" > private_key.pem
         chmod 600 private_key.pem
-        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@94.130.177.235 "mkdir -p /var/www/html/gha/de/ && tar -xvzf /var/www/html/gha/build-de.tar.gz -C /var/www/html/gha/de/ && rm /var/www/html/gha/build-de.tar.gz"
+        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@vircadia.dev "mkdir -p /var/www/vhosts/release/de/ && tar -xvzf /var/www/vhosts/release/build-de.tar.gz -C /var/www/vhosts/release/de/ && rm /var/www/vhosts/release/build-de.tar.gz"
     - name: Deploy japanese documentation
       shell: bash
       run: |
         printf "%s" "${{ secrets.SSH_PRIVATE_KEY }}" > private_key.pem
         chmod 600 private_key.pem
-        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@94.130.177.235 "mkdir -p /var/www/html/gha/jp/ && tar -xvzf /var/www/html/gha/build-jp.tar.gz -C /var/www/html/gha/jp/ && rm /var/www/html/gha/build-jp.tar.gz"
+        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@vircadia.dev "mkdir -p /var/www/vhosts/release/jp/ && tar -xvzf /var/www/vhosts/release/build-jp.tar.gz -C /var/www/vhosts/release/jp/ && rm /var/www/vhosts/release/build-jp.tar.gz"

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -36,14 +36,14 @@ jobs:
       uses: JulianGro/SFTP-Deploy-Action@v1.4
       with:
         username: 'gha'
-        server: '94.130.177.235'
+        server: 'vircadia.dev'
         ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
         local_path: 'docs/build-archives/*'
-        remote_path: '/var/www/html/gha/PR${{ github.event.number }}/'
+        remote_path: '/var/www/vhosts/preview/PR${{ github.event.number }}/'
         args: '-o ConnectTimeout=5'
     - name: Deploy english documentation
       shell: bash
       run: |
         printf "%s" "${{ secrets.SSH_PRIVATE_KEY }}" > private_key.pem
         chmod 600 private_key.pem
-        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@94.130.177.235 "tar -xvzf /var/www/html/gha/PR${{ github.event.number }}/build-en.tar.gz -C /var/www/html/gha/PR${{ github.event.number }}/ && rm /var/www/html/gha/PR${{ github.event.number }}/build-en.tar.gz"
+        ssh -o StrictHostKeyChecking=no -i private_key.pem gha@vircadia.dev "tar -xvzf /var/www/vhosts/preview/PR${{ github.event.number }}/build-en.tar.gz -C /var/www/vhosts/preview/PR${{ github.event.number }}/ && rm /var/www/hvhosts/preview/PR${{ github.event.number }}/build-en.tar.gz"

--- a/.github/workflows/pr_build_info.yml
+++ b/.github/workflows/pr_build_info.yml
@@ -13,6 +13,6 @@ jobs:
         message: |
           **This PR will be available at** https://https://preview-docs.vircadia.dev/PR${{ github.event.number }}/ **once building has completed.**
           Every new commit will trigger a rebuild. Look at the "Checks" to see progress.
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+#        repo-token: ${{ secrets.GITHUB_TOKEN }}
         repo-token-user-login: 'Buildsystem' # The user.login for temporary GitHub tokens
         allow-repeats: false # This is the default

--- a/.github/workflows/pr_build_info.yml
+++ b/.github/workflows/pr_build_info.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: mshick/add-pr-comment@v1
       with:
         message: |
-          **This PR will be available at** http://94.130.177.235/gha/PR${{ github.event.number }}/ **once building has completed.**
+          **This PR will be available at** https://https://preview-docs.vircadia.dev/PR${{ github.event.number }}/ **once building has completed.**
           Every new commit will trigger a rebuild. Look at the "Checks" to see progress.
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         repo-token-user-login: 'Buildsystem' # The user.login for temporary GitHub tokens


### PR DESCRIPTION
This PR changes GHA to work with docs.vircadia.dev hosted by Kalila.